### PR TITLE
react-select now uses a custom class, which is important for honoring dark mode via `prefers-color-scheme: dark`

### DIFF
--- a/server/.env.development
+++ b/server/.env.development
@@ -9,3 +9,4 @@ MONGODB_DOCKER_PORT=27017
 POSTGRESQL_CONNECTION_STRING=postgres://public_readonly:nearprotocol@testnet.db.explorer.indexer.near.dev/testnet_explorer
 #POSTGRESQL_CONNECTION_STRING=postgres://public_readonly:nearprotocol@mainnet.db.explorer.indexer.near.dev/mainnet_explorer
 PORT=8080
+NODE_ENV=development

--- a/src/App.js
+++ b/src/App.js
@@ -295,6 +295,7 @@ export default function App() {
                 options={[{ label: '--- Select All ---', value: '*' }, ...types]}
                 placeholder="Select transaction types"
                 value={selectedTypes}
+                className="my-react-select-container"
                 onChange={onChangeTypes}
                 setState={setSelectedTypes}
                 isMulti

--- a/src/global.css
+++ b/src/global.css
@@ -218,6 +218,12 @@ aside footer *:last-child {
     input:focus {
         box-shadow: 0 0 10em rgba(255, 255, 255, 0.02) inset;
     }
+
+    .my-react-select-container {
+        /* https://github.com/JedWatson/react-select/issues/4067#issuecomment-721672676
+        https://stackoverflow.com/questions/63212723/using-dark-mode-in-react-select */
+        color: gray;
+    }
 }
 
 table {


### PR DESCRIPTION
See "before" screenshot: https://near-foundation.atlassian.net/browse/TTA-17?atlOrigin=eyJpIjoiYzBiZmYzMjNhMjNhNDJhMGI1Zjg0NDEwNmY0OTg2ZjgiLCJwIjoiaiJ9 

After: 
![image](https://user-images.githubusercontent.com/2086493/187294196-0ddebc8d-56b9-4342-a17d-2eac133acaea.png)


